### PR TITLE
feat: optimize single block hashing

### DIFF
--- a/src/keccak256.nr
+++ b/src/keccak256.nr
@@ -112,20 +112,25 @@ fn apply_keccak_permutations<let N: u32>(
 
         state
     } else {
-        // We store the intermediate states in an array to avoid having a dynamic predicate
-        // inside the loop, which can cause a blowup in a constrained runtime.
-        let mut intermediate_states = [state; N / LIMBS_PER_BLOCK + 1];
-        for i in 1..max_blocks {
-            let mut previous_state = intermediate_states[i - 1];
-            for j in 0..LIMBS_PER_BLOCK {
-                previous_state[j] =
-                    previous_state[j] ^ flattened_blocks_array[i * LIMBS_PER_BLOCK + j];
+        if N / LIMBS_PER_BLOCK <= 1 {
+            // Single block: the first permutation above is the only one needed.
+            state
+        } else {
+            // We store the intermediate states in an array to avoid having a dynamic predicate
+            // inside the loop, which can cause a blowup in a constrained runtime.
+            let mut intermediate_states = [state; N / LIMBS_PER_BLOCK + 1];
+            for i in 1..max_blocks {
+                let mut previous_state = intermediate_states[i - 1];
+                for j in 0..LIMBS_PER_BLOCK {
+                    previous_state[j] =
+                        previous_state[j] ^ flattened_blocks_array[i * LIMBS_PER_BLOCK + j];
+                }
+                intermediate_states[i] = keccakf1600(previous_state);
             }
-            intermediate_states[i] = keccakf1600(previous_state);
-        }
 
-        // We can then take the state as of `num_blocks`, ignoring later permutations.
-        intermediate_states[num_blocks - 1]
+            // We can then take the state as of `num_blocks`, ignoring later permutations.
+            intermediate_states[num_blocks - 1]
+        }
     }
 }
 

--- a/src/keccak256/oracle_tests.nr
+++ b/src/keccak256/oracle_tests.nr
@@ -29,6 +29,14 @@ unconstrained fn test_keccak256_135(input: [u8; 135], len: u32) {
 }
 
 #[test]
+unconstrained fn test_keccak256_136(input: [u8; 136], len: u32) {
+    let actual_len = len % 136;
+    let result = keccak256(input, actual_len);
+    let expected = keccak256_hash_oracle(input, actual_len);
+    assert_eq(result, expected);
+}
+
+#[test]
 unconstrained fn test_keccak256_256(input: [u8; 256], len: u32) {
     let actual_len = len % 257;
     let result = keccak256(input, actual_len);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Avoid use of `intermediate_states` if input won't fill first block. This avoids 25 unnecessary reads.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
