### PR TITLE
fix: Update vector syntax

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  MINIMUM_NOIR_VERSION: 1.0.0-beta.17
+  MINIMUM_NOIR_VERSION: 1.0.0-beta.19
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MINIMUM_NOIR_VERSION: v1.0.0-beta.17
+  MINIMUM_NOIR_VERSION: v1.0.0-beta.19
 
 jobs:
   noir-version-list:

--- a/src/keccak256.nr
+++ b/src/keccak256.nr
@@ -172,7 +172,7 @@ fn read_hash_from_state(state: [u64; NUM_KECCAK_LANES]) -> [u8; 32] {
 }
 
 comptime fn unroll_loop(start: u32, end: u32, body: fn(u32) -> Quoted) -> Quoted {
-    let mut iterations: [Quoted] = &[];
+    let mut iterations: [Quoted] = @[];
     for i in start..end {
         iterations = iterations.push_back(body(i));
     }


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

This Repo still uses the deprecated vector syntax which is being removed in https://github.com/noir-lang/noir/pull/12740

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
